### PR TITLE
fixed typo (simplified chinese) in yakuman name

### DIFF
--- a/frontend/src/components/YakumanDisplay.tsx
+++ b/frontend/src/components/YakumanDisplay.tsx
@@ -25,7 +25,7 @@ function getYakumanName(han: Han[]): string {
 			case Han.All_Honors:
 				return "字一色";
 			case Han.All_Green:
-				return "绿一色";
+				return "緑一色";
 			case Han.All_Terminals:
 				return "清老頭";
 			case Han.Thirteen_Orphans:


### PR DESCRIPTION
changed 緑一色 to use correct japanese form of the first kanji instead of simplified chinese