### PR TITLE
remove a redundant request to /contest/{:id}/players

### DIFF
--- a/frontend/src/api/Players.ts
+++ b/frontend/src/api/Players.ts
@@ -1,7 +1,7 @@
 import { Rest, Store } from "majsoul-api";
 import { buildApiUrl } from "./utils";
 
-interface FetchContestPlayerParams {
+export interface FetchContestPlayerParams {
 	contestId: string;
 	gameLimit?: number;
 	ignoredGames?: number;

--- a/frontend/src/components/PlayerStandings.tsx
+++ b/frontend/src/components/PlayerStandings.tsx
@@ -7,9 +7,8 @@ import { Rest } from "majsoul-api";
 import { ContestPlayerDisplay } from "./ContestPlayerDisplay";
 import { useSelector } from "react-redux";
 import { IState } from "src/State";
-import { fetchContestPlayers } from "src/api/Players";
 
-function contestPlayerTeamSort(params: {player: Rest.ContestPlayer<any>, team: string}): number {
+function contestPlayerTeamSort(params: { player: Rest.ContestPlayer<any>, team: string }): number {
 	if (params.player.team.seeded && params.team != null) {
 		return 1;
 	}
@@ -22,20 +21,10 @@ export function PlayerStandings(props: {
 	ignoredGames?: number;
 }): JSX.Element {
 	const contest = useSelector((state: IState) => state.contestsById[props.contestId]);
-	const maxGames = contest?.maxGames;
-	const [contestPlayers, setContestPlayers] = React.useState<Array<Rest.ContestPlayer<any>>>(null);
-
-	React.useEffect(() => {
-		setContestPlayers(null);
-		fetchContestPlayers({
-			contestId: props.contestId,
-			gameLimit: maxGames,
-			ignoredGames: props.ignoredGames
-		}).then(setContestPlayers);
-	}, [props.contestId, props.ignoredGames, contest?.bonusPerGame, maxGames]);
+	const players = contest?.players;
 
 	return <Container className="rounded-bottom bg-dark text-light text-center px-3 py-4">
-		{contestPlayers == null
+		{!players
 			? <Row>
 				<Col>
 					<Spinner animation="border" role="status">
@@ -43,7 +32,7 @@ export function PlayerStandings(props: {
 					</Spinner>
 				</Col>
 			</Row>
-			: contestPlayers
+			: players
 				.map(player => ({
 					player,
 					team: props.allowedTeams == null ? player.team.teams[0] : props.allowedTeams.find(team => player.team.teams.indexOf(team) >= 0)


### PR DESCRIPTION
This should resolve https://github.com/vg-mjg/majsoul-api/issues/17.
It's far from a perfect solution, since it had to maintain the correct behavior on that one special snowflake saki tournament with hardcoded `ignoredGames` parameter, but it should work.